### PR TITLE
Update NuGet source to HTTPS and enhance build system

### DIFF
--- a/Build/Version.targets
+++ b/Build/Version.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
 
-  <PropertyGroup>  
-    <MSBuildCommunityTasksPath Condition=" '$(MSBuildCommunityTasksPath)' == '' ">$(SolutionDir)\packages\MSBuildTasks.1.4.0.88\tools</MSBuildCommunityTasksPath>
+  <PropertyGroup>
+    <MSBuildCommunityTasksPath Condition=" '$(MSBuildCommunityTasksPath)' == '' ">$(SolutionDir)\packages\MSBuildTasks.1.5.0.235\tools</MSBuildCommunityTasksPath>
     <VersionFile Condition=" '$(VersionFile)' == '' ">$(SolutionDir)\Build\Version.txt</VersionFile>
     <GeneratedAssemblyInfoFile Condition=" '$(GeneratedAssemblyInfoFile)' == '' ">$(SolutionDir)\Build\Version.cs</GeneratedAssemblyInfoFile>
-	
-	<BuildDependsOn>
+    
+    <BuildDependsOn>
          SetAssemblyVersion;
          $(BuildDependsOn)
       </BuildDependsOn>
@@ -31,8 +31,8 @@
     <GitVersion LocalPath="$(SolutionDir)" Short="false">
       <Output TaskParameter="CommitHash" PropertyName="GitHash" />
     </GitVersion>
-	
-	<GitBranch LocalPath="$(SolutionDir)">
+    
+    <GitBranch LocalPath="$(SolutionDir)">
          <Output TaskParameter="Branch" PropertyName="GitBranch" />
       </GitBranch>
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,21 @@
 # How to contribute
 
+## Building the project
+
+The repository includes a `Directory.Build.props` file in the root that configures build properties. 
+
+If MediaPortal is not installed in the default location on your system, you'll need to specify the correct path by setting the `MediaPortalInstallDir` property.
+You can do this by adapting the `Directory.Build.props`:
+```xml
+<Project>
+  <PropertyGroup>
+    <MediaPortalInstallDir>C:\Path\To\MediaPortal</MediaPortalInstallDir>
+  </PropertyGroup>
+</Project>
+```
+
+## General contribution guidelines
+
 As websites change constantly, keeping it all working requires quite some work, and we can't do this without the help of the community.
 
 There are three basic parts of this plugin, the core, the MediaPortal specific parts and the parts for the sites itself.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,17 @@
 <Project>
 
     <PropertyGroup>
+        <!-- Installation SubPath in program files folder  -->
+        <_MediaPortalSubPath>Team MediaPortal\MediaPortal\</_MediaPortalSubPath>
+
         <!-- Path to locate external references from MP install path -->
-        <MediaPortalInstallPath Condition="Exists('$(MSBuildProgramFiles32)\Team MediaPortal\MediaPortal\MediaPortal.exe')">$(MSBuildProgramFiles32)\Team MediaPortal\MediaPortal</MediaPortalInstallPath>
-        <MediaPortalInstallPath Condition="'$(MediaPortalInstallPath)' == ''">$(ProgramFiles)\Team MediaPortal\MediaPortal</MediaPortalInstallPath>
+        <MediaPortalInstallPath Condition="'$(MediaPortalInstallPath)' == '' and Exists('$(MSBuildProgramFiles32)\$(_MediaPortalSubPath)MediaPortal.exe')">$(MSBuildProgramFiles32)\$(_MediaPortalSubPath)</MediaPortalInstallPath>
+        <MediaPortalInstallPath Condition="'$(MediaPortalInstallPath)' == '' and Exists('$(ProgramFiles)\$(_MediaPortalSubPath)MediaPortal.exe')">$(ProgramFiles)\$(_MediaPortalSubPath)</MediaPortalInstallPath>
+        <MediaPortalInstallPath Condition="'$(MediaPortalInstallPath)' != '' and !HasTrailingSlash('$(MediaPortalInstallPath)')">$(MediaPortalInstallPath)\</MediaPortalInstallPath>
 
         <!-- true, overwrites $(MediaPortalInstallPath) onlinevideo plugin files with build result -->
         <CopyBuildResultToMediaPortalInstallPath>true</CopyBuildResultToMediaPortalInstallPath>
+
     </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+    <PropertyGroup>
+        <!-- Path to locate external references from MP install path -->
+        <MediaPortalInstallPath Condition="Exists('$(MSBuildProgramFiles32)\Team MediaPortal\MediaPortal\MediaPortal.exe')">$(MSBuildProgramFiles32)\Team MediaPortal\MediaPortal</MediaPortalInstallPath>
+        <MediaPortalInstallPath Condition="'$(MediaPortalInstallPath)' == ''">$(ProgramFiles)\Team MediaPortal\MediaPortal</MediaPortalInstallPath>
+
+        <!-- true, overwrites $(MediaPortalInstallPath) onlinevideo plugin files with build result -->
+        <CopyBuildResultToMediaPortalInstallPath>true</CopyBuildResultToMediaPortalInstallPath>
+    </PropertyGroup>
+
+</Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,6 @@
     <add key="enabled" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="TeamMediaPortal source @ MyGet" value="http://www.myget.org/F/mediaportal/" />
+    <add key="TeamMediaPortal source @ MyGet" value="https://www.myget.org/F/mediaportal/" />
   </packageSources>
 </configuration>

--- a/OnlineVideos.MediaPortal1.sln
+++ b/OnlineVideos.MediaPortal1.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32002.261
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11513.90
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{28BEFB3A-C1A1-427F-B156-83157F30EA3C}"
 EndProject
@@ -32,7 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{2D9515
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{ECC6D240-F5F0-4C9C-A08C-21E85E36307A}"
 	ProjectSection(SolutionItems) = preProject
-		Build.proj = Build.proj
+		Directory.Build.props = Directory.Build.props
 		.build\MSBuild.Community.Tasks.dll = .build\MSBuild.Community.Tasks.dll
 		.build\MSBuild.Community.Tasks.targets = .build\MSBuild.Community.Tasks.targets
 		Build\Version.txt = Build\Version.txt

--- a/OnlineVideos.MediaPortal1/OnlineVideos.MediaPortal1.csproj
+++ b/OnlineVideos.MediaPortal1/OnlineVideos.MediaPortal1.csproj
@@ -41,53 +41,53 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AxInterop.WMPLib">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\AxInterop.WMPLib.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\AxInterop.WMPLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Common.GUIPlugins">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\plugins\Windows\Common.GUIPlugins.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\plugins\Windows\Common.GUIPlugins.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Common.Utils">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\Common.Utils.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\Common.Utils.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Core">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\Core.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Databases">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\Databases.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\Databases.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Dialogs">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\plugins\Windows\Dialogs.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\plugins\Windows\Dialogs.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DirectShowLib">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\DirectShowLib.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\DirectShowLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="GUIHome">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\plugins\Windows\GUIHome.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\plugins\Windows\GUIHome.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="GUIVideos">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\plugins\Windows\GUIVideos.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\plugins\Windows\GUIVideos.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Interop.WMPLib">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\Interop.WMPLib.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\Interop.WMPLib.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
       <Private>False</Private>
     </Reference>
     <Reference Include="log4net">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\log4net.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\log4net.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MediaInfo.Wrapper">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\MediaInfo.Wrapper.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\MediaInfo.Wrapper.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.WebView2.Core, Version=1.0.2277.86, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
       <HintPath>..\Packages\Microsoft.Web.WebView2.1.0.2277.86\lib\net45\Microsoft.Web.WebView2.Core.dll</HintPath>
@@ -96,7 +96,7 @@
       <HintPath>..\Packages\Microsoft.Web.WebView2.1.0.2277.86\lib\net45\Microsoft.Web.WebView2.WinForms.dll</HintPath>
     </Reference>
     <Reference Include="RemotePlugins">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\RemotePlugins.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\RemotePlugins.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -120,7 +120,7 @@
       <HintPath>Trakt\TraktPlugin.dll</HintPath>
     </Reference>
     <Reference Include="Utils">
-      <HintPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\Utils.dll</HintPath>
+      <HintPath>$(MediaPortalInstallPath)\Utils.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OnlineVideos.MediaPortal1/build.targets
+++ b/OnlineVideos.MediaPortal1/build.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
 
   <PropertyGroup>
-    <PluginDestination>$(ProgramFiles)\Team MediaPortal\MediaPortal\plugins\Windows\</PluginDestination>
-    <DataDestination>$(ProgramData)\Team MediaPortal\MediaPortal\</DataDestination>
+    <PluginDestination>$(MediaPortalInstallPath)\plugins\Windows\</PluginDestination>
+    <DataDestination>$(ProgramData)$(_MediaPortalSubPath)\</DataDestination>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
     <IconFiles Include="$(SolutionDir)SiteImages\**\*.*" />
   </ItemGroup>
 
-  <Target Name="AfterBuild">
+  <Target Name="AfterBuild" Condition="'$(CopyBuildResultToMediaPortalInstallPath)' == 'True'">
     <Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(PluginDestination)" />
     <Copy SourceFiles="@(APIFiles)" DestinationFolder="$(PluginDestination)OnlineVideos\" />
     <Copy SourceFiles="@(SiteUtilDllFiles)" DestinationFolder="$(PluginDestination)OnlineVideos\" />
@@ -31,6 +31,6 @@
     <Copy SourceFiles="@(SkinFiles)"
           DestinationFiles="@(SkinFiles->'$(DataDestination)Skin\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(IconFiles)"
-            DestinationFiles="@(IconFiles->'$(DataDestination)thumbs\OnlineVideos\%(RecursiveDir)%(Filename)%(Extension)')" />
+          DestinationFiles="@(IconFiles->'$(DataDestination)thumbs\OnlineVideos\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 </Project>

--- a/OnlineVideos.MediaPortal1/build.targets
+++ b/OnlineVideos.MediaPortal1/build.targets
@@ -23,6 +23,10 @@
     <IconFiles Include="$(SolutionDir)SiteImages\**\*.*" />
   </ItemGroup>
 
+  <Target Name="BeforeBuild">
+    <Error Condition="'$(MediaPortalInstallPath)' == ''" Text="MediaPortalInstallPath is not set." />
+  </Target>
+
   <Target Name="AfterBuild" Condition="'$(CopyBuildResultToMediaPortalInstallPath)' == 'True'">
     <Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(PluginDestination)" />
     <Copy SourceFiles="@(APIFiles)" DestinationFolder="$(PluginDestination)OnlineVideos\" />

--- a/OnlineVideos/OnlineVideos.csproj
+++ b/OnlineVideos/OnlineVideos.csproj
@@ -70,9 +70,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <StartAction>Program</StartAction>
-    <StartProgram>$(ProgramFiles)\Team MediaPortal\MediaPortal\mediaportal.exe</StartProgram>
+    <StartProgram>$(MediaPortalInstallPath)\mediaportal.exe</StartProgram>
     <RemoteDebugEnabled>false</RemoteDebugEnabled>
-    <StartWorkingDirectory>$(ProgramFiles)\Team MediaPortal\MediaPortal</StartWorkingDirectory>
+    <StartWorkingDirectory>$(MediaPortalInstallPath)</StartWorkingDirectory>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
@@ -425,6 +425,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\Packages\Microsoft.Web.WebView2.1.0.2277.86\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\Packages\Microsoft.Web.WebView2.1.0.2277.86\build\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\Packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\Packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />    
   </Target>
   <Import Project="..\Packages\Microsoft.Web.WebView2.1.0.2277.86\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\Packages\Microsoft.Web.WebView2.1.0.2277.86\build\Microsoft.Web.WebView2.targets')" />
+  <Import Project="..\Packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\Packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />  
 </Project>

--- a/OnlineVideos/packages.config
+++ b/OnlineVideos/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="HtmlAgilityPack" version="1.11.46" targetFramework="net48" />
   <package id="Microsoft.Web.WebView2" version="1.0.2277.86" targetFramework="net48" />
-  <package id="MSBuildTasks" version="1.4.0.88" targetFramework="net472" />
+  <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net48" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="SubtitleDownloader" version="3.1.4" targetFramework="net48" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # Description
 
-OnlineVideos is a plug-in for the open-source media center application [MediaPortal](http://www.team-mediaportal.com/) running on the Windows platform. The main goal of this plug-in is the seamless integration of video content provided by various websites with the main application. In order to achieve this, playback is heavily dependent on [directshow](http://wikipedia.org/wiki/DirectShow) filters installed on the users operating system. The discovery or scraping of playback links is very flexible and can be done by reading rss feeds, parsing html with regular expressions or even programming against APIs provided by websites.
+OnlineVideos is a plug-in for the open-source media center application [MediaPortal](http://www.team-mediaportal.com/) running on the Windows platform.
+The main goal of this plug-in is the seamless integration of video content provided by various websites with the main application.
+In order to achieve this, playback is heavily dependent on [directshow](http://wikipedia.org/wiki/DirectShow) filters installed on the users operating system.
+The discovery or scraping of playback links is very flexible and can be done by reading rss feeds, parsing html with regular expressions 
+or even programming against APIs provided by websites.
 
-The plug-in interface will unify the user experience from all the different websites into one simple structure. Every site will span a hierarchical tree of categories, each showing a set of videos with descriptions and thumbnails. Support for searching, filtering, bookmarking favorites and downloading is included as well.
+The plug-in interface will unify the user experience from all the different websites into one simple structure.
+Every site will span a hierarchical tree of categories, each showing a set of videos with descriptions and thumbnails.
+Support for searching, filtering, bookmarking favorites and downloading is included as well.
 
 # [Screenshots](https://github.com/MediaPortal/mp-onlinevideos2/wiki/ScreenShots)
 
 # Supported Sites
 
-This short list gives a first impression of what you can expect inside OnlineVideos. The complete listing is available [here](https://ov2.team-mediaportal.com/).
+This short list gives a first impression of what you can expect inside OnlineVideos.
+The complete listing is available [here](https://ov2.team-mediaportal.com/).
 
     Global
         YouTube 

--- a/SiteUtilProjects/OnlineVideos.Sites.geoffstewart/OnlineVideos.Sites.geoffstewart.csproj
+++ b/SiteUtilProjects/OnlineVideos.Sites.geoffstewart/OnlineVideos.Sites.geoffstewart.csproj
@@ -30,7 +30,7 @@
     <FileAlignment>4096</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <OutputPath>$(ProgramFiles)\Team MediaPortal\MediaPortal\plugins\Windows\OnlineVideos\</OutputPath>
+    <OutputPath>$(MediaPortalInstallPath)\Team MediaPortal\MediaPortal\plugins\Windows\OnlineVideos\</OutputPath>
     <DebugSymbols>True</DebugSymbols>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>


### PR DESCRIPTION
Switch the TeamMediaPortal NuGet source to HTTPS for improved security and update the build system for better configurability and flexibility. This includes upgrading the MSBuildTasks package, centralizing paths, and modernizing the build process.